### PR TITLE
[WindowManagerService] fix starting window issue

### DIFF
--- a/services/core/java/com/android/server/wm/WindowManagerService.java
+++ b/services/core/java/com/android/server/wm/WindowManagerService.java
@@ -4361,7 +4361,7 @@ public class WindowManagerService extends IWindowManager.Stub
                 AppWindowToken ttoken = findAppWindowToken(transferFrom);
                 if (ttoken != null) {
                     WindowState startingWindow = ttoken.startingWindow;
-                    if (startingWindow != null) {
+                    if (startingWindow != null && ttoken.startingView != null) {
                         // In this case, the starting icon has already been displayed, so start
                         // letting windows get shown immediately without any more transitions.
                         mSkipAppTransitionAnimation = true;


### PR DESCRIPTION
Symptom:
1. Acitivity A and B belong to same task.
2. A is started and start B in its code
3. B is opened with blank screen

If starting icon has been display, both startingWindow and
startingView should not be null.
Current logic only uses judgement on startWindow. In above
case, it leads startingView set to null as A and B shares
the same starting window due to same task. Then system will
not get chance to remove startingView as it is null.

It needs add judgement on startingView.

Change-Id: I6cfa1a3ebce93ce435cc2d9ada239b1e808988de